### PR TITLE
Custom CSS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,28 @@ Example of a dark mode theme:
 }
 ```
 
+<p align="justify">
+It is also possible to use a custom css file by providing the path to the file:
+</p>
+
+```json
+"theme": {
+  "custom_css": "/path/to/custom.css"
+}
+```
+
+<p align="justify">
+Keep in mind, even if you provide a custom css file, the background and foreground colors will still be applied as long as you provide the correct templating keys in your custom css file like so:
+</p>
+
+```css
+body {
+  background: {{.Background}};
+  color: {{.Foreground}};
+}
+```
+
+
 #### YAML
 
 ```yml

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -171,3 +171,28 @@ func TestValidate(t *testing.T) {
 		t.Fatal()
 	}
 }
+
+func TestCustomCSS(t *testing.T) {
+	var config = `{
+		"addr": "0.0.0.0:8080",
+		"use_tls": false,
+		"cert_file": "",
+		"key_file": "",
+		"behind_proxy": false,
+		"title": "Easy Gate",
+		"theme": {
+			"custom_css": "tmp.css",
+		},
+		"groups": [],
+		"services": [],
+		"notes": []
+		}`
+	cfg, err := Unmarshal([]byte(config))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Theme.CustomCss != "tmp.css" {
+		t.Fatal()
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 )
 
@@ -38,6 +39,17 @@ func validateConfig(cfg *Config) error {
 	}
 	if !isHexColor(cfg.Theme.Foreground) {
 		return fmt.Errorf("invalid foreground color")
+	}
+
+	if cfg.Theme.CustomCss != "" {
+		fi, err := os.Stat(cfg.Theme.CustomCss)
+		if err != nil {
+			return fmt.Errorf("invalid custom CSS file path")
+		}
+
+		if fi.IsDir() {
+			return fmt.Errorf("custom CSS path is a directory")
+		}
 	}
 
 	for _, service := range cfg.Services {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"embed"
-	"fmt"
 	"html/template"
 	"log"
 	"net/http"
@@ -100,8 +99,6 @@ func (e Engine) Serve() {
 
 		addr := getAddr(status, c)
 		data := getData(status, addr)
-
-		fmt.Println(data)
 
 		return c.Render("template/index", fiber.Map{
 			"Title": status.Title,

--- a/internal/engine/static/styles/style.css
+++ b/internal/engine/static/styles/style.css
@@ -1,0 +1,122 @@
+@font-face {
+      font-family: 'Roboto';
+      src: url('/roboto-regular.ttf') format('truetype');
+    }
+
+    body {
+      background-color: {{.Background}};
+      color: {{.Foreground}};
+      font-family: 'Roboto',
+      sans-serif;
+    }
+
+    a {
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .main {
+      padding-top: 1.5rem;
+      padding-bottom: 1.5rem;
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+
+    .category-title {
+      margin-left: 0.25rem;
+    }
+
+    .category-block {
+      display: grid;
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+      margin-top: 0.5rem;
+      margin-bottom: 0.5rem;
+    }   
+
+    .service-block {
+      padding: 0.3rem;
+      border-radius: 0.5rem;
+      box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
+      cursor: pointer;
+      transition: box-shadow 0.2s ease;
+      margin: 0.25rem;
+    }
+
+    .service-block:hover {
+      box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.2);
+    }
+
+    .service-icon {
+      fill: {{.Foreground}};
+      margin: auto;
+    }
+
+    .service-title {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-weight: 600;
+      width: 83.33%;
+    }
+
+    .notes-block {
+      margin-top: 3rem;
+      margin-bottom: 0.5rem;
+      display: grid;
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    .note-block {
+      padding: 1rem;
+      border-radius: 0.25rem;
+      box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
+      margin: 0.25rem;
+    }
+
+    .note-icon {
+      fill: {{.Foreground}};
+      margin-right: 0.5rem;
+    }
+
+    .note-title {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-weight: 600;
+      width: 83.33%;
+    }
+
+    .flex-center {
+      align-items: center;
+      display: flex;
+    }
+
+    @media (min-width: 768px) {
+      .category-block {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+       .notes-block {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .category-block {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+
+      .notes-block {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1280px) {
+      .category-block {
+        grid-template-columns: repeat(7, minmax(0, 1fr));
+      }
+
+      .notes-block {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+    }

--- a/internal/engine/template/index.html
+++ b/internal/engine/template/index.html
@@ -6,130 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{.Title}}</title>
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-  <style>
-    @font-face {
-      font-family: 'Roboto';
-      src: url('/roboto-regular.ttf') format('truetype');
-    }
-
-    body {
-      background-color: {{.Background}};
-      color: {{.Foreground}};
-      font-family: 'Roboto',
-      sans-serif;
-    }
-
-    a {
-      text-decoration: none;
-      color: inherit;
-    }
-
-    .main {
-      padding-top: 1.5rem;
-      padding-bottom: 1.5rem;
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-
-    .category-title {
-      margin-left: 0.25rem;
-    }
-
-    .category-block {
-      display: grid;
-      grid-template-columns: repeat(1, minmax(0, 1fr));
-      margin-top: 0.5rem;
-      margin-bottom: 0.5rem;
-    }   
-
-    .service-block {
-      padding: 0.3rem;
-      border-radius: 0.5rem;
-      box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
-      cursor: pointer;
-      transition: box-shadow 0.2s ease;
-      margin: 0.25rem;
-    }
-
-    .service-block:hover {
-      box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.2);
-    }
-
-    .service-icon {
-      fill: {{.Foreground}};
-      margin: auto;
-    }
-
-    .service-title {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      font-weight: 600;
-      width: 83.33%;
-    }
-
-    .notes-block {
-      margin-top: 3rem;
-      margin-bottom: 0.5rem;
-      display: grid;
-      grid-template-columns: repeat(1, minmax(0, 1fr));
-    }
-
-    .note-block {
-      padding: 1rem;
-      border-radius: 0.25rem;
-      box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
-      margin: 0.25rem;
-    }
-
-    .note-icon {
-      fill: {{.Foreground}};
-      margin-right: 0.5rem;
-    }
-
-    .note-title {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      font-weight: 600;
-      width: 83.33%;
-    }
-
-    .flex-center {
-      align-items: center;
-      display: flex;
-    }
-
-    @media (min-width: 768px) {
-      .category-block {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-
-       .notes-block {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-    }
-
-    @media (min-width: 1024px) {
-      .category-block {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-      }
-
-      .notes-block {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-    }
-
-    @media (min-width: 1280px) {
-      .category-block {
-        grid-template-columns: repeat(7, minmax(0, 1fr));
-      }
-
-      .notes-block {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-      }
-    }
-  </style>
+  <link rel="stylesheet" href="/style.css" />
 </head>
 
 <body>
@@ -167,8 +44,7 @@
         {{range $index, $note := .Data.Notes}}
         <div class="note-block">
           <div class="flex-center">
-            <svg class="note-icon" width="18px" height="18px" xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 448 512">
+            <svg class="note-icon" width="18px" height="18px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
               <path
                 d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H288V368c0-26.5 21.5-48 48-48H448V96c0-35.3-28.7-64-64-64H64zM448 352H402.7 336c-8.8 0-16 7.2-16 16v66.7V480l32-32 64-64 32-32z" />
             </svg>

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -4,4 +4,5 @@ package theme
 type Theme struct {
 	Background string `json:"background" yaml:"background"`
 	Foreground string `json:"foreground" yaml:"foreground"`
+	CustomCss  string `json:"custom_css" yaml:"custom_css"`
 }


### PR DESCRIPTION
This PR add the capability to support custom css.

1 - a new config key `custom_css` was added to the config file
2 - validation of such file is performed during the config validation
3 - the custom background and foreground are still applied if the user provide the templating keys

I also updated the readme with the new key